### PR TITLE
Accepts map signature keys and encryption is now optional.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,6 @@ defmodule Bau.MixProject do
   end
 
   defp deps do
-    [{:poison, "~> 3.1"}, {:jose, "~> 1.8.4"}]
+    [{:poison, "~> 3.1"}, {:jose, "~> 1.9.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
-  "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
+  "jose": {:hex, :jose, "1.9.0", "4167c5f6d06ffaebffd15cdb8da61a108445ef5e85ab8f5a7ad926fdf3ada154", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/test/bau/xerpa/jwt_test.exs
+++ b/test/bau/xerpa/jwt_test.exs
@@ -6,8 +6,12 @@ defmodule Bau.Xerpa.JWTTest do
   describe "jwt" do
     setup [:default_setup]
 
-    test "encode . decode", %{options: options, enc_key: enc_key, sig_key: sig_key} do
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, options)
+    test "encode . decode", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, options)
 
       timestamp = DateTime.to_unix(options[:timestamp])
 
@@ -16,27 +20,55 @@ defmodule Bau.Xerpa.JWTTest do
                 "exp" => timestamp + options[:expires_in_secs],
                 "iat" => timestamp,
                 "iss" => options[:claim_iss]
-              }} == decode(jwt, sig_key, enc_key, options)
+              }} == decode(jwt, publ_sig_key, enc_key, options)
     end
 
-    test "iss validation", %{options: options, enc_key: enc_key, sig_key: sig_key} do
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, options)
+    test "encode . decode | no encryption", %{
+      options: options,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, nil, options)
+
+      timestamp = DateTime.to_unix(options[:timestamp])
+
+      assert {:ok,
+              %{
+                "exp" => timestamp + options[:expires_in_secs],
+                "iat" => timestamp,
+                "iss" => options[:claim_iss]
+              }} == decode(jwt, publ_sig_key, nil, options)
+    end
+
+    test "iss validation", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, options)
 
       new_options = Keyword.put(options, :claim_iss, "https://iss.invalid")
-      assert {:error, {:bad_claim, :iss, %{}}} = decode(jwt, sig_key, enc_key, new_options)
+      assert {:error, {:bad_claim, :iss, %{}}} = decode(jwt, publ_sig_key, enc_key, new_options)
 
       new_options = Keyword.put(options, :claim_iss, "https://localhost.localdomain/bad-prefix")
-      assert {:error, {:bad_claim, :iss, %{}}} = decode(jwt, sig_key, enc_key, new_options)
+      assert {:error, {:bad_claim, :iss, %{}}} = decode(jwt, publ_sig_key, enc_key, new_options)
     end
 
-    test "exp validation", %{options: options, enc_key: enc_key, sig_key: sig_key} do
+    test "exp validation", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
       new_options = Keyword.put(options, :expires_in_secs, -300)
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, new_options)
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, new_options)
 
-      assert {:error, {:bad_claim, :exp, %{}}} = decode(jwt, sig_key, enc_key, options)
+      assert {:error, {:bad_claim, :exp, %{}}} = decode(jwt, publ_sig_key, enc_key, options)
     end
 
-    test "iat validation", %{options: options, enc_key: enc_key, sig_key: sig_key} do
+    test "iat validation", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
       expires_in_secs = 600 + DateTime.to_unix(DateTime.utc_now())
 
       new_options =
@@ -44,24 +76,62 @@ defmodule Bau.Xerpa.JWTTest do
         |> Keyword.put(:timestamp, DateTime.from_unix!(expires_in_secs))
         |> Keyword.put(:expires_in_secs, expires_in_secs)
 
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, new_options)
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, new_options)
 
-      assert {:error, {:bad_claim, :iat, %{}}} = decode(jwt, sig_key, enc_key, options)
+      assert {:error, {:bad_claim, :iat, %{}}} = decode(jwt, publ_sig_key, enc_key, options)
     end
 
-    test "bad signature/encryption", %{options: options, enc_key: enc_key, sig_key: sig_key} do
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, options)
-      assert {:error, :bad_signature} == decode(jwt, new_sig_key(), enc_key, options)
-      assert {:error, :bad_encryption} == decode(jwt, sig_key, new_enc_key(), options)
+    test "bad signature/encryption", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      %{publ: other_sig_key} = new_sig_key()
+
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, options)
+      assert {:error, :bad_signature} == decode(jwt, other_sig_key, enc_key, options)
+      assert {:error, :bad_encryption} == decode(jwt, publ_sig_key, new_enc_key(), options)
     end
 
-    test "key rotation", %{options: options, enc_key: enc_key, sig_key: sig_key} do
-      assert {:ok, jwt} = encode(%{}, sig_key, enc_key, options)
-      assert {:ok, jwt1} = decode(jwt, sig_key, enc_key, options)
-      assert {:ok, ^jwt1} = decode(jwt, [sig_key, new_sig_key()], enc_key, options)
-      assert {:ok, ^jwt1} = decode(jwt, [new_sig_key(), sig_key], enc_key, options)
-      assert {:ok, ^jwt1} = decode(jwt, sig_key, [enc_key, new_enc_key()], options)
-      assert {:ok, ^jwt1} = decode(jwt, sig_key, [new_enc_key(), enc_key], options)
+    test "key rotation", %{
+      options: options,
+      enc_key: enc_key,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      %{publ: other_sig_key} = new_sig_key()
+
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, enc_key, options)
+      assert {:ok, jwt1} = decode(jwt, publ_sig_key, enc_key, options)
+      assert {:ok, ^jwt1} = decode(jwt, [publ_sig_key, other_sig_key], enc_key, options)
+      assert {:ok, ^jwt1} = decode(jwt, [other_sig_key, publ_sig_key], enc_key, options)
+      assert {:ok, ^jwt1} = decode(jwt, publ_sig_key, [enc_key, new_enc_key()], options)
+      assert {:ok, ^jwt1} = decode(jwt, publ_sig_key, [new_enc_key(), enc_key], options)
+    end
+
+    test "key rotation | no encryption keys but flag not set", %{
+      options: options,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, nil, options)
+      assert {:error, :bad_encryption} = decode(jwt, [publ_sig_key], nil, options)
+      assert {:error, :bad_encryption} = decode(jwt, publ_sig_key, [], options)
+      assert {:error, :bad_encryption} = decode(jwt, publ_sig_key, [nil], options)
+    end
+
+    test "key rotation | no encryption", %{
+      options: options,
+      sig_key: %{priv: priv_sig_key, publ: publ_sig_key}
+    } do
+      options = Keyword.put(options, :no_encryption, true)
+      %{publ: other_sig_key} = new_sig_key()
+
+      assert {:ok, jwt} = encode(%{}, priv_sig_key, nil, options)
+      assert {:ok, jwt1} = decode(jwt, publ_sig_key, nil, options)
+      assert {:ok, ^jwt1} = decode(jwt, [publ_sig_key, other_sig_key], nil, options)
+      assert {:ok, ^jwt1} = decode(jwt, [other_sig_key, publ_sig_key], nil, options)
+      assert {:ok, ^jwt1} = decode(jwt, publ_sig_key, [], options)
+      assert {:ok, ^jwt1} = decode(jwt, publ_sig_key, [nil], options)
+      assert {:ok, ^jwt1} = decode(jwt, publ_sig_key, [nil, nil], options)
     end
   end
 
@@ -82,6 +152,11 @@ defmodule Bau.Xerpa.JWTTest do
 
   defp new_sig_key do
     :base64url.encode(:crypto.strong_rand_bytes(64))
+    priv_key = JOSE.JWK.generate_key({:rsa, 2048})
+    {_, publ_key} = JOSE.JWK.to_public_map(priv_key)
+    {_, priv_key} = JOSE.JWK.to_map(priv_key)
+
+    %{priv: priv_key, publ: publ_key}
   end
 
   defp new_enc_key do


### PR DESCRIPTION
As chaves públicas do Cognito são mapas:

```json
[
  {
    "use": "sig",
    "n": "km_K2d7qUCkLAwPD1Wbzqf8vlx3HZ-6dEYZZWgEj4kFIUMMIi1yf-jQ9uNpbEJbnhpjYzLyqwvKLdYS0UHyfXgUWwPpUhhcTSlDoNPdevJ8Pml5ufFqJQrB9PKtNzalJGacyIA5DrFjhH8ZcBvFJPokgtAof8QKqzNwoNTPbSVB6Xb57Exqok0x5dNlApBq9f1ACnkvSNabzLBzdKmcL0RVuFdL5VBPMEQ8wR5nzA1MOzhhLE8MHAXSE5Affz2OWOEoyj7DHFL5iy8BPphzB5MrBXddrUkc6nRMqx5-UvDUEH1IoeJDqg7-9N4eK-BxO9Ks-Uj51D5469_MObUexnQ",
    "kty": "RSA",
    "kid": "g7strNpjsxXSrvRt+Ni9MCk5sFdLrcYAeZatdTQ1AoE=",
    "e": "AQAB",
    "alg": "RS256"
  },
  {
    "use": "sig",
    "n": "inwVTklKywb4LoFw6QajIzf9yWSYcVBUeesx5ViBPD6CXsT25N7yvwJJ2eK6P3p9DI_-Z9ieab1zmFjljXqPoDenyQhTFmETY_R0xN6uBS9vuhlQpxNikptAN8GlTbqGNav-UIRHGKmVMmXxMzfAzkspSla05DF9uqaMF5asRsqN-KcnbQJKSdVcAQZhIJdqo3HRw1-aJ1ehTXyXpqPAghB3eKaE7B1b2gkZonfyN7RMY8Rr_Y0GW8O2yaoQo5RpyCguSSuVRmdOj9CLMRSVJRD63a0iJj1GJ70mBBtHUlvD7zDOmPrXVg0FXEbg0voEgMeQEKtaq-y7HxlZarZR4w",
    "kty": "RSA",
    "kid": "uoo8APeJ4PIiPyPDCPNasuw2jmX+Yz+GAxoS/lWmnh8=",
    "e": "AQAB",
    "alg": "RS256"
  }
]
```