### PR TITLE
Adds StatsD UDP support

### DIFF
--- a/lib/bau/xerpa/statsd.ex
+++ b/lib/bau/xerpa/statsd.ex
@@ -1,0 +1,90 @@
+defmodule Bau.Xerpa.StatsD do
+  @moduledoc """
+  Formats and sends metrics for StatsD.
+
+  To configure, add this to `config.exs` or similar:
+
+  ```
+  config :bau, :statsd,
+    host: "127.0.0.1",
+    port: 8125
+  ```
+  """
+
+  def send_metrics(metrics, config \\ Application.get_env(:bau, :statsd))
+
+  def send_metrics(metrics, config) when is_list(metrics) do
+    to_send = Enum.join(metrics, "\n")
+
+    with {:ok, address} <- Keyword.fetch(config, :host),
+         true <- is_binary(address) || {:error, :invalid_host},
+         {:ok, port} <- Keyword.fetch(config, :port),
+         true <- is_integer(port) || {:error, :invalid_port},
+         {:ok, socket} <- :gen_udp.open(0) do
+      try do
+        :gen_udp.send(socket, to_charlist(address), port, to_send)
+      after
+        :gen_udp.close(socket)
+      end
+    end
+  end
+
+  def send_metrics("" <> metric, config) do
+    send_metrics([metric], config)
+  end
+
+  def counter("" <> bucket, count, opts \\ []) when is_integer(count) and count >= 0 do
+    sampling_freq = get_sampling_freq(opts)
+
+    "#{bucket}:#{count}|c#{sampling_freq}"
+  end
+
+  def gauge("" <> bucket, opts \\ []) do
+    inc = Keyword.get(opts, :inc)
+    dec = Keyword.get(opts, :dec)
+    now = Keyword.get(opts, :now)
+
+    defined = Enum.count([inc, dec, now], &(not is_nil(&1)))
+
+    cond do
+      defined != 1 ->
+        nil
+
+      now && now >= 0 ->
+        "#{bucket}:#{now}|g"
+
+      now && now < 0 ->
+        "#{bucket}:0|g\n#{bucket}:#{now}|g"
+
+      inc && inc >= 0 ->
+        "#{bucket}:+#{inc}|g"
+
+      dec && dec >= 0 ->
+        "#{bucket}:-#{dec}|g"
+
+      :otherwise ->
+        nil
+    end
+  end
+
+  def timing("" <> bucket, value, unit, opts \\ [])
+      when unit in [:ms, :h] and is_integer(value) and value >= 0 do
+    sampling_freq = get_sampling_freq(opts)
+
+    "#{bucket}:#{value}|#{unit}#{sampling_freq}"
+  end
+
+  def sets("" <> bucket, value) when is_binary(value) or is_integer(value) do
+    "#{bucket}:#{value}|s"
+  end
+
+  defp get_sampling_freq(opts) do
+    sampling = Keyword.get(opts, :sampling_frequency)
+
+    if sampling && is_float(sampling) do
+      "|@#{sampling}"
+    else
+      ""
+    end
+  end
+end

--- a/test/bau/xerpa/statsd_test.exs
+++ b/test/bau/xerpa/statsd_test.exs
@@ -1,0 +1,123 @@
+defmodule Bau.Xerpa.StatsDTest do
+  use ExUnit.Case, async: true
+
+  alias Bau.Xerpa.StatsD
+
+  describe "send_metrics" do
+    setup do
+      {:ok, port} = spawn_udp_server()
+      config = [host: "localhost", port: port]
+
+      {:ok, %{config: config}}
+    end
+
+    test "sends single metric", %{config: config} do
+      metric = StatsD.counter("foobar", 123)
+      assert StatsD.send_metrics(metric, config) == :ok
+
+      assert_receive {:udp, _erl_port, _addr, _port, 'foobar:123|c'}
+    end
+
+    test "sends multiple metrics", %{config: config} do
+      metrics = [
+        StatsD.counter("counter", 123),
+        StatsD.gauge("gauge", now: 321),
+        StatsD.timing("timing", 200, :ms),
+        StatsD.sets("sets", "value")
+      ]
+
+      assert StatsD.send_metrics(metrics, config) == :ok
+
+      assert_receive {:udp, _erl_port, _addr, _port,
+                      'counter:123|c\ngauge:321|g\ntiming:200|ms\nsets:value|s'}
+    end
+  end
+
+  describe "counter" do
+    test "simple counter" do
+      assert StatsD.counter("foobar", 123) == "foobar:123|c"
+    end
+
+    test "with sampling freq" do
+      assert StatsD.counter("foobar", 123, sampling_frequency: 0.2) == "foobar:123|c|@0.2"
+    end
+  end
+
+  describe "gauge" do
+    test "simple gauge : now positive" do
+      assert StatsD.gauge("foobar", now: 123) == "foobar:123|g"
+    end
+
+    test "simple gauge : now negative" do
+      assert StatsD.gauge("foobar", now: -123) == "foobar:0|g\nfoobar:-123|g"
+    end
+
+    test "simple gauge : inc" do
+      assert StatsD.gauge("foobar", inc: 123) == "foobar:+123|g"
+    end
+
+    test "simple gauge : dec" do
+      assert StatsD.gauge("foobar", dec: 123) == "foobar:-123|g"
+    end
+
+    test "no arguments" do
+      assert is_nil(StatsD.gauge("foobar"))
+    end
+
+    test "multiple arguments" do
+      assert is_nil(StatsD.gauge("foobar", dec: 123, inc: 123))
+      assert is_nil(StatsD.gauge("foobar", now: 123, inc: 123))
+      assert is_nil(StatsD.gauge("foobar", now: 123, dec: 123))
+      assert is_nil(StatsD.gauge("foobar", now: 123, dec: 123, inc: 123))
+    end
+  end
+
+  describe "timing" do
+    test "simple timing : ms" do
+      assert StatsD.timing("foobar", 200, :ms) == "foobar:200|ms"
+    end
+
+    test "simple timing : h" do
+      assert StatsD.timing("foobar", 200, :h) == "foobar:200|h"
+    end
+
+    test "with sampling freq" do
+      assert StatsD.timing("foobar", 200, :ms, sampling_frequency: 0.25) == "foobar:200|ms|@0.25"
+    end
+  end
+
+  describe "sets" do
+    test "integer" do
+      assert StatsD.sets("foobar", 123) == "foobar:123|s"
+    end
+
+    test "string" do
+      assert StatsD.sets("foobar", "value") == "foobar:value|s"
+    end
+  end
+
+  defp spawn_udp_server() do
+    spawn_udp_server(32_000)
+  end
+
+  defp spawn_udp_server(port) when port > 65_535, do: :error
+
+  defp spawn_udp_server(port) do
+    case :gen_udp.open(port) do
+      {:ok, socket} ->
+        on_exit(fn -> :gen_udp.close(socket) end)
+        this = self()
+        spawn(fn -> listen(socket, this) end)
+        {:ok, port}
+
+      {:error, :eaddrinuse} ->
+        spawn_udp_server(port + 1)
+    end
+  end
+
+  defp listen(socket, destination) do
+    :gen_udp.recv(socket, 4096)
+
+    listen(socket, destination)
+  end
+end


### PR DESCRIPTION
This adds support for sending metrics to an UDP StatsD server. With this, we can collect arbitrary metrics in our application, since every machine has a NetData server that is scraped by Prometheus.

![DeepinScreenshot_select-area_20191113143415](https://user-images.githubusercontent.com/16166434/68788760-cb702300-0622-11ea-9db9-ec7078f986f7.png)

Metric types:
https://github.com/statsd/statsd/blob/master/docs/metric_types.md
https://github.com/netdata/netdata/blob/master/collectors/statsd.plugin/README.md

References:
https://github.com/netdata/netdata
https://github.com/statsd/statsd