### PR TITLE
Adds Exception Handler Middleware for Absinthe

### DIFF
--- a/lib/bau/xerpa/absinthe/middleware/exception_handler.ex
+++ b/lib/bau/xerpa/absinthe/middleware/exception_handler.ex
@@ -1,0 +1,66 @@
+defmodule Bau.Xerpa.Absinthe.Middleware.ExceptionHandler do
+  @behaviour Absinthe.Middleware
+
+  @moduledoc """
+  Absinthe does not call middlewares further down the chain when one
+  middleware call raises an exception. This hinders instrumentation such
+  as terminating an Appsignal transaction or sending timing metrics to
+  StatsD.
+
+  With this handler, exceptions are caught and arbitrary handling can be
+  provided. Also, the middleware pipeline continues, allowing clean up
+  functions to be called.
+
+  How to use:
+
+  ```elixir
+  def middleware(middleware, _field, %Absinthe.Type.Object{identifier:
+  identifier}) when identifier in [:query, :mutation, :subscription] do
+  Enum.map(middleware, fn m -> ExceptionHandler.wrap(m, on_error: &your_error_handler/2) end)
+  end
+
+  def middleware(middleware, _field, _object), do: middleware
+  ```
+
+  ... where `your_error_handler/2` has type `(%Absinthe.Resolution{}, term()) -> %Absinthe.Resolution{}`.
+  """
+
+  @impl true
+  def call(resolution, opts) do
+    spec = Keyword.fetch!(opts, :spec)
+    on_error_fn = Keyword.get(opts, :on_error, fn resolution, _error -> resolution end)
+
+    try do
+      execute(spec, resolution)
+    rescue
+      error ->
+        resolution
+        |> on_error_fn.(error)
+        |> Absinthe.Resolution.put_result({:error, "internal server error"})
+    end
+  end
+
+  def wrap(spec) do
+    {__MODULE__, spec: spec}
+  end
+
+  def wrap(spec, on_error: on_error_fn) when is_function(on_error_fn, 2) do
+    {__MODULE__, spec: spec, on_error: on_error_fn}
+  end
+
+  defp execute({{module, function}, config}, resolution) do
+    apply(module, function, [resolution, config])
+  end
+
+  defp execute({module, config}, resolution) do
+    apply(module, :call, [resolution, config])
+  end
+
+  defp execute(module, resolution) when is_atom(module) do
+    apply(module, :call, [resolution, []])
+  end
+
+  defp execute(function, resolution) when is_function(function, 2) do
+    function.(resolution, [])
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,9 @@ defmodule Bau.MixProject do
   end
 
   defp deps do
-    [{:poison, "~> 3.1"}]
+    [
+      {:poison, "~> 3.1"},
+      {:absinthe, ">= 1.4.0 and < 1.5.0"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "absinthe": {:hex, :absinthe, "1.4.16", "0933e4d9f12652b12115d5709c0293a1bf78a22578032e9ad0dad4efee6b9eb1", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "jose": {:hex, :jose, "1.9.0", "4167c5f6d06ffaebffd15cdb8da61a108445ef5e85ab8f5a7ad926fdf3ada154", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/bau/xerpa/absinthe/middleware/exception_handler_test.exs
+++ b/test/bau/xerpa/absinthe/middleware/exception_handler_test.exs
@@ -1,0 +1,87 @@
+defmodule Bau.Xerpa.Absinthe.Middleware.ExceptionHandlerTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+
+    alias Bau.Xerpa.Absinthe.Middleware.ExceptionHandler
+
+    defp on_error_fn(resolution = %{context: %{echo_fn: echo_fn}}, exception) do
+      echo_fn.(resolution, exception)
+
+      resolution
+    end
+
+    def middleware(middleware, _field, %Absinthe.Type.Object{identifier: :query}) do
+      Enum.map(middleware, fn m -> ExceptionHandler.wrap(m, on_error: &on_error_fn/2) end)
+    end
+
+    def middleware(middleware, _field, _object), do: middleware
+
+    query do
+      field :success, :boolean do
+        resolve(fn _, _, _ ->
+          {:ok, true}
+        end)
+      end
+
+      field :failure, :boolean do
+        resolve(fn _, _, _ ->
+          {:error, :some_error}
+        end)
+      end
+
+      field :exception, :boolean do
+        resolve(fn _, _, _ ->
+          raise "boom"
+        end)
+      end
+    end
+  end
+
+  alias Bau.Xerpa.Absinthe.Middleware.ExceptionHandlerTest.TestSchema
+
+  setup do
+    this = self()
+
+    echo_fn = fn resolution, exception ->
+      send(this, {:called, %{resolution: resolution, exception: exception}})
+    end
+
+    {:ok, %{echo_fn: echo_fn}}
+  end
+
+  test "does not call handler on success response", %{echo_fn: echo_fn} do
+    assert Absinthe.run!("query { success }", TestSchema, context: %{echo_fn: echo_fn}) == %{
+             data: %{"success" => true}
+           }
+
+    refute_receive {:called, _}
+  end
+
+  test "does not call handler on error response", %{echo_fn: echo_fn} do
+    assert Absinthe.run!("query { failure }", TestSchema, context: %{echo_fn: echo_fn}) == %{
+             data: %{"failure" => nil},
+             errors: [
+               %{locations: [%{column: 0, line: 1}], message: "some_error", path: ["failure"]}
+             ]
+           }
+
+    refute_receive {:called, _}
+  end
+
+  test "calls handler on unhandled exceptions", %{echo_fn: echo_fn} do
+    assert Absinthe.run!("query { exception }", TestSchema, context: %{echo_fn: echo_fn}) == %{
+             data: %{"exception" => nil},
+             errors: [
+               %{
+                 locations: [%{column: 0, line: 1}],
+                 message: "internal server error",
+                 path: ["exception"]
+               }
+             ]
+           }
+
+    assert_receive {:called, %{resolution: %Absinthe.Resolution{}, exception: %RuntimeError{}}}
+  end
+end


### PR DESCRIPTION
Absinthe does not call middlewares further down the chain when one
middleware call raises an exception. This hinders instrumentation such
as terminating an Appsignal transaction or sending timing metrics to
StatsD.

With this handler, exceptions are caught and arbitrary handling can be
provided. Also, the middleware pipeline continues, allowing clean up
functions to be called.

How to use:

```elixir
def middleware(middleware, _field, %Absinthe.Type.Object{identifier:
identifier}) when identifier in [:query, :mutation, :subscription] do
  Enum.map(middleware, fn m -> ExceptionHandler.wrap(m, on_error: &your_error_handler/2) end)
end

def middleware(middleware, _field, _object), do: middleware
```

... where `your_error_handler/2` has type `(%Absinthe.Resolution{}, term()) -> %Absinthe.Resolution{}`.