### PR TITLE
Bugfix: ParseJSON must call next if already parsed

### DIFF
--- a/lib/bau/xerpa/conduit/plug/parse_json.ex
+++ b/lib/bau/xerpa/conduit/plug/parse_json.ex
@@ -28,7 +28,7 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSON do
     already_parsed? = get_header(message, @parsed_flag_header) == "true"
 
     if already_parsed? do
-      message
+      next.(message)
     else
       case Jason.decode(message.body) do
         {:ok, decoded} ->

--- a/test/bau/xerpa/conduit/plug/parse_json_test.exs
+++ b/test/bau/xerpa/conduit/plug/parse_json_test.exs
@@ -19,11 +19,15 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
       |> Message.put_new_correlation_id("correlation-id")
       |> Message.put_source("queue")
 
-    next = fn in_msg -> in_msg end
+    next = fn in_msg ->
+      send(self(), :next_called)
+      in_msg
+    end
 
     out_msg = ParseJSON.call(msg, next, [])
     assert out_msg == msg
     assert out_msg.status == :ack
+    assert_receive :next_called
   end
 
   test "does not attempt to decode if content-type != application/json" do
@@ -38,11 +42,15 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
       |> Message.put_new_correlation_id("correlation-id")
       |> Message.put_source("queue")
 
-    next = fn in_msg -> in_msg end
+    next = fn in_msg ->
+      send(self(), :next_called)
+      in_msg
+    end
 
     out_msg = ParseJSON.call(msg, next, [])
     assert out_msg == msg
     assert out_msg.status == :ack
+    assert_receive :next_called
   end
 
   test "always attempts to parse if force = true" do
@@ -58,7 +66,10 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
       |> Message.put_new_correlation_id("correlation-id")
       |> Message.put_source("queue")
 
-    next = fn in_msg -> in_msg end
+    next = fn in_msg ->
+      send(self(), :next_called)
+      in_msg
+    end
 
     out_msg = ParseJSON.call(msg, next, force: true)
 
@@ -67,6 +78,8 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
              |> Message.put_body(decoded_payload)
              |> Message.put_content_type("application/json")
              |> Message.put_header("x-xerpa-bau-parsed-json", "true")
+
+    assert_receive :next_called
   end
 
   test "successfully parses" do
@@ -79,7 +92,10 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
       |> Message.put_content_type("application/json")
       |> Message.put_body(encoded_payload)
 
-    next = fn x -> x end
+    next = fn in_msg ->
+      send(self(), :next_called)
+      in_msg
+    end
 
     out_msg = ParseJSON.call(msg, next, [])
 
@@ -88,6 +104,8 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSONTest do
              |> Message.put_body(decoded_payload)
              |> Message.put_content_type("application/json")
              |> Message.put_header("x-xerpa-bau-parsed-json", "true")
+
+    assert_receive :next_called
   end
 
   test "parse failure" do

--- a/test/bau/xerpa/tesla/middleware/request_id_forwarder_test.exs
+++ b/test/bau/xerpa/tesla/middleware/request_id_forwarder_test.exs
@@ -11,7 +11,7 @@ defmodule Bau.Xerpa.Tesla.Middleware.RequestIdForwarderTest do
   end
 
   test "does nothing when there is no :request_id in logger metadata" do
-    Process.put(:logger_metadata, {true, other_key: "value"})
+    Logger.metadata(other_key: "value")
 
     original_env = %Env{}
     assert {:ok, env} = RequestIdForwarder.call(original_env, [], "http://some.url")
@@ -19,7 +19,7 @@ defmodule Bau.Xerpa.Tesla.Middleware.RequestIdForwarderTest do
   end
 
   test "does nothing when there is a :request_id with wrong type" do
-    Process.put(:logger_metadata, {true, request_id: :wrong_value})
+    Logger.metadata(request_id: :wrong_value)
 
     original_env = %Env{}
     assert {:ok, env} = RequestIdForwarder.call(original_env, [], "http://some.url")
@@ -27,7 +27,7 @@ defmodule Bau.Xerpa.Tesla.Middleware.RequestIdForwarderTest do
   end
 
   test "adds 'x-request-id' header when request_id is found in process dictionary" do
-    Process.put(:logger_metadata, {true, request_id: "request_id"})
+    Logger.metadata(request_id: "request_id")
 
     original_env = %Env{headers: [{"original_headers", "value"}]}
     assert {:ok, env} = RequestIdForwarder.call(original_env, [], "http://some.url")


### PR DESCRIPTION
if the message was already parsed (during DLQ processing, for
instance), the `next` continuation was not being called, effectively
avoiding publishing the rejected message to its DLQ.