### PR TITLE
fix for otp 24

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,11 +8,19 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: ['20.3', '22.3']
-        elixir: ['1.6.5', '1.8.2', '1.9.4', '1.10.4']
+        otp: ['20.3', '22.3', '24.0']
+        elixir: ['1.6.5', '1.8.2', '1.9.4', '1.10.4', '1.11.4']
         exclude:
           - elixir: '1.10.4'
             otp: '20.3'
+          - elixir: '1.11.4'
+            otp: '20.3'
+          - elixir: '1.8.2'
+            otp: '24.0'
+          - elixir: '1.9.4'
+            otp: '24.0'
+          - elixir: '1.6.5'
+            otp: '24.0'
     steps:
       - uses: actions/checkout@v2.3.3
       - uses: erlef/setup-beam@v1.7.0

--- a/lib/bau/xerpa/enum.ex
+++ b/lib/bau/xerpa/enum.ex
@@ -131,7 +131,7 @@ defmodule Bau.Xerpa.Enum do
       if ecto3_plus? do
         quote do
           def embed_as(_format), do: :self
-          def equal?(t1, t2), do: t1.name == t2.name
+          def equal?(t1, t2), do: t1 == t2
         end
       end
 


### PR DESCRIPTION
in some occasions, a `nil` creeps in the call to `equal?/2` Ecto
callback in OTP 24.0, which breaks when one tries to access its
`.name`. since enums are all equal and have no associated metadata, we
can simply compare then structurally.