### PR TITLE
bugfix: parse json + dead letter plug interfence

### DIFF
--- a/lib/bau/xerpa/conduit/plug/dead_letter.ex
+++ b/lib/bau/xerpa/conduit/plug/dead_letter.ex
@@ -45,7 +45,10 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetter do
 
     message
     |> put_header("x-original-routing-key", original_routing_key)
-    |> broker.publish(publish_to, opts)
+    |> broker.publish(
+      publish_to,
+      Keyword.put(opts, :skip_parse_json?, true)
+    )
 
     case action do
       :nack ->

--- a/lib/bau/xerpa/conduit/plug/parse_json.ex
+++ b/lib/bau/xerpa/conduit/plug/parse_json.ex
@@ -7,12 +7,11 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSON do
 
   require Logger
 
-  @parsed_flag_header "x-xerpa-bau-parsed-json"
-
   def call(message, next, opts) do
-    force? = Keyword.get(opts, :force, false)
+    # to avoid pipeline order dependencies (dead letter + parse + format)
+    skip_parse_json? = Keyword.get(opts, :skip_parse_json?, false)
 
-    if force? or message.content_type == "application/json" do
+    if not skip_parse_json? and message.content_type == "application/json" do
       attempt_decode(message, next)
     else
       next.(message)
@@ -24,32 +23,25 @@ defmodule Bau.Xerpa.Conduit.Plug.ParseJSON do
     correlation_id = message.correlation_id
     queue = message.source
     exchange = get_header(message, "exchange")
-    # to avoid pipeline order dependencies (dead letter + parse + format)
-    already_parsed? = get_header(message, @parsed_flag_header) == "true"
 
-    if already_parsed? do
-      next.(message)
-    else
-      case Jason.decode(message.body) do
-        {:ok, decoded} ->
-          message
-          |> put_content_type("application/json")
-          |> put_header(@parsed_flag_header, "true")
-          |> put_body(decoded)
-          |> next.()
+    case Jason.decode(message.body) do
+      {:ok, decoded} ->
+        message
+        |> put_content_type("application/json")
+        |> put_body(decoded)
+        |> next.()
 
-        {:error, error} ->
-          msg = Exception.format(:error, error)
+      {:error, error} ->
+        msg = Exception.format(:error, error)
 
-          Logger.error("invalid json message. discarding.\n#{msg}",
-            request_id: request_id,
-            correlation_id: correlation_id,
-            queue: queue,
-            exchange: exchange
-          )
+        Logger.error("invalid json message. discarding.\n#{msg}",
+          request_id: request_id,
+          correlation_id: correlation_id,
+          queue: queue,
+          exchange: exchange
+        )
 
-          %{message | status: :reject}
-      end
+        %{message | status: :reject}
     end
   end
 end

--- a/test/bau/xerpa/conduit/plug/dead_letter_test.exs
+++ b/test/bau/xerpa/conduit/plug/dead_letter_test.exs
@@ -9,6 +9,100 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
     end
   end
 
+  defmodule ParseJSONDeadLetterRoundtrip do
+    use Conduit.Subscriber
+
+    def process(message, _opts) do
+      send(self(), {:process_message, message})
+      succeed? = Conduit.Message.get_header(message, "succeed") == "true"
+
+      if succeed? do
+        message
+      else
+        %{message | status: :reject}
+      end
+    end
+  end
+
+  defmodule IntegrationBroker do
+    use Conduit.Broker, otp_app: :bau_test
+
+    pipeline :error_handling do
+      plug(Bau.Xerpa.Conduit.Plug.DeadLetter,
+        publish_to: :error,
+        broker: __MODULE__
+      )
+    end
+
+    pipeline :deserialize do
+      plug(Bau.Xerpa.Conduit.Plug.ParseJSON)
+    end
+
+    pipeline :serialize do
+      plug(Conduit.Plug.Format)
+    end
+
+    incoming Bau.Xerpa.Conduit.Plug.DeadLetterTest do
+      pipe_through([:error_handling, :deserialize])
+
+      subscribe(
+        :roundtrip,
+        ParseJSONDeadLetterRoundtrip,
+        from: "queue"
+      )
+    end
+
+    outgoing do
+      pipe_through([:serialize])
+      publish(:error, exchange: "dlx")
+    end
+  end
+
+  # alias Bau.Xerpa.Conduit.Plug.DeadLetterTest.IntegrationBroker
+
+  describe "parse json <-> dead letter roundtrip" do
+    test "can reprocess json messages" do
+      Application.put_env(:bau_test, IntegrationBroker, adapter: Conduit.TestAdapter)
+      routing_key = "routing_key"
+
+      original_decoded_body = %{
+        "some_key" => ["value", 10]
+      }
+
+      original_encoded_body = Jason.encode!(original_decoded_body)
+
+      msg =
+        %Message{}
+        |> Message.put_header("routing_key", routing_key)
+        |> Message.put_content_type("application/json")
+        |> Message.put_body(original_encoded_body)
+
+      IntegrationBroker.receives(:roundtrip, msg)
+
+      assert_received {:publish, IntegrationBroker, :error, dlq_msg = %Message{},
+                       [adapter: Conduit.TestAdapter],
+                       exchange: "dlx",
+                       skip_parse_json?: true,
+                       publish_to: :error,
+                       broker: IntegrationBroker}
+
+      assert_received {:process_message, %Message{body: %{}}}
+
+      assert dlq_msg.body == original_encoded_body
+      assert dlq_msg.status == :reject
+
+      reprocessed_dlq_msg =
+        dlq_msg
+        |> Message.put_header("succeed", "true")
+        |> Map.put(:status, :ack)
+
+      IntegrationBroker.receives(:roundtrip, reprocessed_dlq_msg)
+
+      assert_received {:process_message, %Message{body: %{}}}
+      refute_received {:publish, IntegrationBroker, _, _, _, _}
+    end
+  end
+
   describe "when the message is rejected" do
     defmodule RejectDeadLetter do
       use Conduit.Subscriber
@@ -24,7 +118,9 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
       msg = Message.put_header(%Message{}, "routing_key", routing_key)
       assert %Message{status: :ack} = RejectDeadLetter.run(msg)
 
-      assert_received {:publish, :error, dlq_msg = %Message{}, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, dlq_msg = %Message{},
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
+
       assert Message.get_header(dlq_msg, "routing_key") == routing_key
       assert Message.get_header(dlq_msg, "x-original-routing-key") == routing_key
     end
@@ -40,7 +136,9 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
 
       assert %Message{status: :ack} = RejectDeadLetter.run(msg)
 
-      assert_received {:publish, :error, dlq_msg = %Message{}, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, dlq_msg = %Message{},
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
+
       assert Message.get_header(dlq_msg, "routing_key") == routing_key
       assert Message.get_header(dlq_msg, "x-original-routing-key") == original_routing_key
     end
@@ -59,7 +157,8 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
     test "it publishes the message to the dead letter destination and nacks the message" do
       assert %Message{status: :nack} = NackedDeadLetter.run(%Message{})
 
-      assert_received {:publish, :error, %Message{}, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, %Message{},
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
     end
 
     test "it preserves x-original-routing-key when present" do
@@ -73,7 +172,9 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
 
       assert %Message{status: :nack} = NackedDeadLetter.run(msg)
 
-      assert_received {:publish, :error, dlq_msg = %Message{}, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, dlq_msg = %Message{},
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
+
       assert Message.get_header(dlq_msg, "routing_key") == routing_key
       assert Message.get_header(dlq_msg, "x-original-routing-key") == original_routing_key
     end
@@ -92,7 +193,8 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
         ErroredDeadLetter.run(%Message{})
       end)
 
-      assert_received {:publish, :error, %Message{} = message, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, %Message{} = message,
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
 
       assert Message.get_header(message, "exception") =~ "failure"
     end
@@ -110,7 +212,9 @@ defmodule Bau.Xerpa.Conduit.Plug.DeadLetterTest do
         ErroredDeadLetter.run(msg)
       end)
 
-      assert_received {:publish, :error, dlq_msg = %Message{}, broker: Broker, publish_to: :error}
+      assert_received {:publish, :error, dlq_msg = %Message{},
+                       skip_parse_json?: true, broker: Broker, publish_to: :error}
+
       assert Message.get_header(dlq_msg, "routing_key") == routing_key
       assert Message.get_header(dlq_msg, "x-original-routing-key") == original_routing_key
     end


### PR DESCRIPTION
when moving rejected messages from the DLQ back to the original queue
for reprocessing, the ParseJSON plug was incorretly being skipped,
leading to the impossibility of such messages to be reprocessed.